### PR TITLE
Fixes set-env security vulnerability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Add tag
         run: |
           NEW_SHA="$(git rev-parse --short HEAD)"
-          echo "::set-env name=NEW_SHA::${NEW_SHA}"
+          echo "NEW_SHA=${NEW_SHA}" >> $GITHUB_ENV
           git tag -a "$(git describe --abbrev=0 --tags)-nightly$(date +%Y%m%d)+${NEW_SHA}" -m "nightly release"
 
       - name: Set previous sha/tag
@@ -40,8 +40,8 @@ jobs:
           PREVIOUS_SHA="$(echo "${PREVIOUS_TAG}" | grep -oP '.*\+\K.*' )"
           if [ -n "${PREVIOUS_SHA}" ]; then
             git tag -a "${PREVIOUS_TAG}" -m "prev-nightly" "${PREVIOUS_SHA}" && \
-              echo "::set-env name=PREVIOUS_SHA::${PREVIOUS_SHA}" && \
-              echo "::set-env name=GORELEASER_PREVIOUS_TAG::${PREVIOUS_TAG}"
+              echo "PREVIOUS_SHA=${PREVIOUS_SHA}" >> $GITHUB_ENV && \
+              echo "GORELEASER_PREVIOUS_TAG=${PREVIOUS_TAG}" >> $GITHUB_ENV
           fi
 
       - uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
This commit fixes the security vulnerability that is present when using the `set-env` and `add-path` arguments. See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ for more information. @haya14busa I tested it out on my [master branch](https://github.com/rickstaa/nightly/runs/1497691915?check_suite_focus=true) and it seems to fix the set-env errors.