### PR TITLE
bump Go v1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
               echo "GORELEASER_PREVIOUS_TAG=${PREVIOUS_TAG}" >> $GITHUB_ENV
           fi
 
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
       - uses: goreleaser/goreleaser-action@v2
         if: env.NEW_SHA != env.PREVIOUS_SHA
         with:


### PR DESCRIPTION
stable builds of reviewdog are now built with Go v1.16. https://github.com/reviewdog/reviewdog/pull/980
so nightly builds follow it.

and this fixes https://github.com/reviewdog/nightly/issues/7
`darwin/arm64` is available from Go v1.16.